### PR TITLE
Fix dead links on downloads page

### DIFF
--- a/src/pages/downloads.astro
+++ b/src/pages/downloads.astro
@@ -31,7 +31,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           <p class="muted">
             Træningsapp med fokus på struktur, progression og local-first logik.
           </p>
-          <p><a href="#">APK / build kommer snart</a></p>
+          <p class="muted">Offentligt build er ikke frigivet endnu.</p>
           <p><a href="/apps/sovereign-strength/">Læs mere om appen →</a></p>
         </div>
 
@@ -40,7 +40,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           <p class="muted">
             Økonomiværktøj til overblik og beslutninger uden black-box logik.
           </p>
-          <p><a href="#">Build kommer snart</a></p>
+          <p class="muted">Offentligt build er ikke frigivet endnu.</p>
           <p><a href="/apps/sovereign-finance/">Læs mere om appen →</a></p>
         </div>
 
@@ -49,7 +49,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           <p class="muted">
             Rolig plantepleje med rytmer, observation og lokal data.
           </p>
-          <p><a href="#">Build kommer snart</a></p>
+          <p class="muted">Offentligt build er ikke frigivet endnu.</p>
           <p><a href="/apps/sovereign-planta/">Læs mere om appen →</a></p>
         </div>
       </div>
@@ -60,24 +60,24 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <div class="wrapper">
       <div class="section-head">
         <h2>Dokumentation</h2>
-        <p class="muted">PDF’er, noter og andre materialer relateret til projektet.</p>
+        <p class="muted">Noter og materialer relateret til projektet.</p>
       </div>
 
       <div class="grid grid-2">
         <div class="card">
-          <h3>Systemnoter</h3>
+          <h3>Arkitektur</h3>
           <p class="muted">
-            Overblik over struktur, site, apps og udviklingsspor.
+            Overblik over site-struktur, apps, proxy og udviklingsspor.
           </p>
-          <p><a href="#">Systemnote kommer snart</a></p>
+          <p><a href="/architecture/">Læs arkitektur →</a></p>
         </div>
 
         <div class="card">
-          <h3>Arkitektur og principper</h3>
+          <h3>Principper</h3>
           <p class="muted">
-            Dokumenter om local-first retning, åben kode og teknisk struktur.
+            Grundprincipperne bag local-first retning, åben kode og rolig teknologi.
           </p>
-          <p><a href="#">Dokumentation kommer snart</a></p>
+          <p><a href="/principper/">Læs principper →</a></p>
         </div>
       </div>
     </div>
@@ -92,12 +92,11 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
       <div class="grid grid-2">
         <div class="card">
-          <h3>Nextcloud / filrum</h3>
+          <h3>Offentlige filer</h3>
           <p class="muted">
-            På sigt kan denne sektion kobles til offentlige shares fra Nextcloud, så
-            dokumenter og ressourcer ikke behøver bo direkte i sitet.
+            Offentlige filshares er ikke åbnet endnu. Når de frigives,
+            vil de blive linket her i stedet for at gemme døde links bag pæn tekst.
           </p>
-          <p><a href="#">Offentlige filer kommer snart</a></p>
         </div>
 
         <div class="card">
@@ -105,7 +104,11 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           <p class="muted">
             Kode, repos og versionshistorik findes i projektets GitHub-spor.
           </p>
-          <p><a href="https://github.com/jakobbskov" target="_blank" rel="noopener noreferrer">Se GitHub →</a></p>
+          <p>
+            <a href="https://github.com/jakobbskov" target="_blank" rel="noopener noreferrer">
+              Se GitHub →
+            </a>
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Removes dead `href="#"` links from the downloads page
- Replaces unavailable builds with non-clickable status text
- Links documentation cards to existing internal pages: `/architecture/` and `/principper/`
- Keeps the GitHub resource link

## Validation
- `grep -R 'href="#"' src/pages/downloads.astro` → no matches
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 20 pages generated

## Risk
Low. Content-only change to `src/pages/downloads.astro`. No deploy, proxy, build config or styling changes.