### PR TITLE
Fix mobile hero layout

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1505,3 +1505,63 @@ h3 {
   }
 }
 
+
+/* -------------------------------- */
+/* Mobile hero layout fix           */
+/* -------------------------------- */
+
+@media (max-width: 768px) {
+  .hero--with-bg {
+    overflow: hidden;
+  }
+
+  .hero--with-bg .hero-layout {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.35rem;
+  }
+
+  .hero-copy {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .hero-copy h1 {
+    max-width: 11ch;
+  }
+
+  .hero-copy p {
+    max-width: 100%;
+  }
+
+  .hero-system-panel {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    margin-top: 0.25rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .hero-bg {
+    opacity: 0.42;
+  }
+
+  .hero-bg__svg {
+    min-height: 520px;
+  }
+
+  .hero-system-panel {
+    border-radius: 22px;
+  }
+
+  .hero-system-panel__meta {
+    gap: 0.45rem;
+  }
+
+  .hero-system-panel__pill {
+    font-size: 0.8rem;
+    padding: 0.38rem 0.62rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a mobile-specific override for the landing page hero layout
- Forces hero copy and the system panel to stack vertically on mobile
- Ensures the system panel uses full available mobile width instead of being forced into a second grid column
- Reduces mobile hero background opacity and tightens panel pills on small screens

## Validation
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 20 pages generated
- Manual mobile test via local dev server → hero text, buttons and system panel display correctly without the broken side-by-side layout

## Risk
Low to medium. CSS-only change affecting the landing page hero on mobile. Desktop layout is unchanged by the new media queries.