### PR TITLE
Tighten homepage copy flow

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,75 +55,37 @@ const featuredProjekter = projekter.filter((p) => p.data.featured);
   <RealityStrip />
 
   <section class="section">
-    <div class="wrapper reading">
-      <h2>Hvad Innosocia er</h2>
-
-      <p>
-        Innosocia er et lille digitalt laboratorium for idéer og værktøjer,
-        der tager digital suverænitet alvorligt.
-      </p>
-
-      <p>
-        I stedet for endnu en platform handler det om at udvikle simple,
-        forklarbare systemer som mennesker faktisk kan forstå,
-        vedligeholde og bruge over lang tid.
-      </p>
-    </div>
-  </section>
-
-  <section class="section">
-    <div class="wrapper reading">
-      <h2>Hvorfor det findes</h2>
-
-      <p>
-        Meget moderne software er bygget omkring platformafhængighed,
-        abonnementer og lukkede systemer.
-      </p>
-
-      <p>
-        Det skaber effektive tjenester, men også skrøbelige digitale
-        økosystemer, hvor brugere mister kontrol over data,
-        værktøjer og arbejdsgange.
-      </p>
-
-      <p>
-        Innosocia er et forsøg på at undersøge et andet spor:
-        local-first software, mere gennemsigtig logik og værktøjer
-        der hjælper mennesker med at tænke klarere i stedet for
-        at gøre dem afhængige af endnu et dashboard.
-      </p>
-    </div>
-  </section>
-
-  <section class="section">
     <div class="wrapper">
       <div class="section-head">
-        <h2>Hvad der bygges her</h2>
-        <p class="muted">Innosocia samler tre typer arbejde.</p>
+        <h2>Kort fortalt</h2>
+        <p class="muted">
+          Innosocia bygger og beskriver små, forklarbare digitale systemer,
+          der kan drives uden tung platformafhængighed.
+        </p>
       </div>
 
       <div class="grid grid-3">
         <div class="card">
-          <h3><a href="/apps/">Apps</a></h3>
+          <h3>Bygget til praksis</h3>
           <p class="muted">
-            Sovereign-apps til økonomi, træning og praktisk hverdag bygget
-            med local-first logik og forklarbare beslutningssystemer.
+            Apps og prototyper skal kunne forstås, vedligeholdes og bruges
+            uden at gemme hele logikken bag et sort dashboard.
           </p>
         </div>
 
         <div class="card">
-          <h3><a href="/ideer/">Idéer</a></h3>
+          <h3>Local-first som retning</h3>
           <p class="muted">
-            Essays og refleksioner om digital suverænitet,
-            local-first software og mere robuste digitale arbejdsformer.
+            Data, drift og beslutningslogik skal så vidt muligt ligge tæt på
+            brugeren i stedet for at forsvinde ind i en fjern platform.
           </p>
         </div>
 
         <div class="card">
-          <h3><a href="/projekter/">Projekter</a></h3>
+          <h3>Idéer testet i virkeligheden</h3>
           <p class="muted">
-            Konkrete udviklingsspor hvor idéerne omsættes
-            til systemer, værktøjer og eksperimenter.
+            Teksterne, appsene og projekterne hænger sammen:
+            idéerne skal kunne omsættes til noget, der faktisk kan køre.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replaces three repetitive intro sections with one clearer `Kort fortalt` section
- Reduces repeated messaging around digital sovereignty, local-first and apps/projects
- Lets the homepage reach the concrete Apps, Idéer and Projekter sections faster
- Keeps the existing hero, RealityStrip, cards, components and routing intact

## Validation
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 20 pages generated
- Manual local visual review performed before commit

## Risk
Low. Content-only change to `src/pages/index.astro`. No CSS, component, build config, deploy script or proxy changes.