### PR TITLE
Replace homepage link grid with focused closing CTA

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -168,39 +168,35 @@ const featuredProjekter = projekter.filter((p) => p.data.featured);
   <section class="section">
     <div class="wrapper">
       <div class="section-head">
-        <h2>Find rundt</h2>
-        <p class="muted">Direkte adgang til de vigtigste sider på sitet.</p>
+        <h2>Næste skridt</h2>
+        <p class="muted">
+          Start med det mest konkrete, læs principperne bag, eller tag kontakt.
+        </p>
       </div>
 
       <div class="grid grid-3">
         <div class="card">
-          <h3><a href="/apps/">Apps</a></h3>
-          <p class="muted">Oversigt over Sovereign-apps og værktøjer.</p>
+          <h3><a href="/apps/">Se apps</a></h3>
+          <p class="muted">
+            Gå direkte til Sovereign-apps og de konkrete værktøjer,
+            der udvikles under Innosocia.
+          </p>
         </div>
 
         <div class="card">
-          <h3><a href="/ideer/">Idéer</a></h3>
-          <p class="muted">Tekster om digital suverænitet og local-first software.</p>
+          <h3><a href="/principper/">Læs principper</a></h3>
+          <p class="muted">
+            Få den korte version af retningen: local-first, forståelig logik,
+            rolig teknologi og lav platformafhængighed.
+          </p>
         </div>
 
         <div class="card">
-          <h3><a href="/projekter/">Projekter</a></h3>
-          <p class="muted">Initiativer, prototyper og udviklingsspor.</p>
-        </div>
-
-        <div class="card">
-          <h3><a href="/principper/">Principper</a></h3>
-          <p class="muted">Grundidéer og arbejdsprincipper bag Innosocia.</p>
-        </div>
-
-        <div class="card">
-          <h3><a href="/om/">Om</a></h3>
-          <p class="muted">Baggrund, formål og retning for Innosocia.</p>
-        </div>
-
-        <div class="card">
-          <h3><a href="/kontakt/">Kontakt</a></h3>
-          <p class="muted">Kontaktoplysninger og muligheder for henvendelse.</p>
+          <h3><a href="/kontakt/">Tag kontakt</a></h3>
+          <p class="muted">
+            Brug kontaktsiden, hvis du vil spørge ind til projekter,
+            samarbejde eller praktisk anvendelse.
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replaces the six-card `Find rundt` section with a focused `Næste skridt` section
- Reduces repeated navigation links at the bottom of the homepage
- Keeps three clearer next actions: `Se apps`, `Læs principper`, and `Tag kontakt`

## Validation
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 20 pages generated
- `git diff --check` → passed

## Risk
Low. Content-only change to `src/pages/index.astro`. No CSS, components, routing, build config, deploy script or proxy changes.