### PR TITLE
Add automatic deploy status

### DIFF
--- a/public/status.json
+++ b/public/status.json
@@ -1,0 +1,10 @@
+{
+  "site": "innosocia.dk",
+  "generated_by": "fallback",
+  "checked_at": null,
+  "branch": null,
+  "commit": null,
+  "ok": false,
+  "routes": [],
+  "note": "Status is updated automatically by scripts/deploy.sh after successful live validation."
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,6 +8,7 @@ REQUIRED_FILES=(
   "dist/index.html"
   "dist/robots.txt"
   "dist/sitemap-index.xml"
+  "dist/status.json"
 )
 
 LIVE_URLS=(
@@ -16,6 +17,7 @@ LIVE_URLS=(
   "https://innosocia.dk/apps/"
   "https://innosocia.dk/status/"
   "https://innosocia.dk/sitemap-index.xml"
+  "https://innosocia.dk/status.json"
 )
 
 echo "=== Innosocia.dk deploy ==="
@@ -67,6 +69,7 @@ echo "=== Deploy dist/ to ${REMOTE_HOST}:${REMOTE_WEBROOT}/ ==="
 rsync -av --delete dist/ "${REMOTE_HOST}:${REMOTE_WEBROOT}/"
 
 echo "=== Live validation ==="
+STATUS_ROUTES_JSON=""
 for url in "${LIVE_URLS[@]}"; do
   status="$(curl -sS -o /dev/null -w "%{http_code}" "$url")"
   server="$(curl -sSI "$url" | awk 'tolower($1)=="server:" {print $2}' | tr -d '\r' | head -n 1)"
@@ -82,6 +85,49 @@ for url in "${LIVE_URLS[@]}"; do
     echo "ERROR: Unexpected server for $url: $server"
     exit 1
   fi
+
+  route_json="$(python3 - <<PYJSON
+import json
+print(json.dumps({
+    "url": "$url",
+    "status": int("$status"),
+    "server": "$server",
+    "ok": True,
+}, ensure_ascii=False))
+PYJSON
+)"
+
+  if [[ -z "$STATUS_ROUTES_JSON" ]]; then
+    STATUS_ROUTES_JSON="$route_json"
+  else
+    STATUS_ROUTES_JSON="$STATUS_ROUTES_JSON,$route_json"
+  fi
 done
+
+echo "=== Write deploy status ==="
+CHECKED_AT="$(date -Iseconds)"
+COMMIT="$(git rev-parse --short HEAD)"
+
+python3 - <<PYJSON
+import json
+from pathlib import Path
+
+status = {
+    "site": "innosocia.dk",
+    "generated_by": "scripts/deploy.sh",
+    "checked_at": "$CHECKED_AT",
+    "branch": "$BRANCH",
+    "commit": "$COMMIT",
+    "ok": True,
+    "routes": [$STATUS_ROUTES_JSON],
+    "note": "Generated after successful live validation.",
+}
+
+Path("dist/status.json").write_text(
+    json.dumps(status, ensure_ascii=False, indent=2) + "\n"
+)
+PYJSON
+
+rsync -av dist/status.json "${REMOTE_HOST}:${REMOTE_WEBROOT}/status.json"
 
 echo "=== Deploy complete ==="

--- a/src/pages/status.astro
+++ b/src/pages/status.astro
@@ -21,6 +21,104 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <section class="section">
     <div class="wrapper">
       <div class="section-head">
+        <h2>Seneste verificerede deploy</h2>
+        <p class="muted">
+          Denne driftsstatus opdateres automatisk af deploy-scriptet efter live-validering.
+        </p>
+      </div>
+
+      <div class="grid grid-2">
+        <div class="card">
+          <h3 id="deploy-status-title">Status indlæses</h3>
+          <p class="muted" id="deploy-status-summary">
+            Henter seneste status fra <code>/status.json</code>.
+          </p>
+          <p class="muted" id="deploy-status-meta"></p>
+          <p><a href="/status.json">Se maskinlæsbar status →</a></p>
+        </div>
+
+        <div class="card">
+          <h3>Live routes</h3>
+          <div id="deploy-status-routes" class="status-route-list">
+            <p class="muted">Indlæser route-status…</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    const title = document.getElementById("deploy-status-title");
+    const summary = document.getElementById("deploy-status-summary");
+    const meta = document.getElementById("deploy-status-meta");
+    const routes = document.getElementById("deploy-status-routes");
+
+    const escapeHtml = (value) =>
+      String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+
+    const formatDate = (value) => {
+      if (!value) return "ukendt tidspunkt";
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return value;
+      return date.toLocaleString("da-DK", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      });
+    };
+
+    fetch("/status.json", { cache: "no-store" })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Statusfil returnerede ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        const ok = Boolean(data.ok);
+        title.textContent = ok ? "Live-site valideret" : "Status kræver opmærksomhed";
+        summary.textContent = data.note || "Ingen statusnote angivet.";
+        meta.textContent = `Senest tjekket: ${formatDate(data.checked_at)} · Branch: ${data.branch || "ukendt"} · Commit: ${data.commit || "ukendt"}`;
+
+        const routeItems = Array.isArray(data.routes) ? data.routes : [];
+
+        if (routeItems.length === 0) {
+          routes.innerHTML = '<p class="muted">Ingen route-checks er registreret endnu.</p>';
+          return;
+        }
+
+        routes.innerHTML = routeItems
+          .map((route) => {
+            const routeOk = route.ok ? "OK" : "Fejl";
+            const status = route.status ?? "ukendt";
+            const server = route.server || "ukendt server";
+            const url = route.url || "#";
+
+            return `
+              <div class="status-route">
+                <strong>${escapeHtml(routeOk)}</strong>
+                <a href="${escapeHtml(url)}">${escapeHtml(url)}</a>
+                <span>${escapeHtml(status)} · ${escapeHtml(server)}</span>
+              </div>
+            `;
+          })
+          .join("");
+      })
+      .catch((error) => {
+        title.textContent = "Status kunne ikke indlæses";
+        summary.textContent = "Statusfilen kunne ikke hentes. Det betyder ikke nødvendigvis nedetid, men statusvisningen skal undersøges.";
+        meta.textContent = error.message;
+        routes.innerHTML = '<p class="muted">Ingen route-status kunne vises.</p>';
+      });
+  </script>
+
+  <section class="section">
+    <div class="wrapper">
+      <div class="section-head">
         <h2>Nu</h2>
         <p class="muted">Det der faktisk findes og er i bevægelse.</p>
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1565,3 +1565,48 @@ h3 {
     padding: 0.38rem 0.62rem;
   }
 }
+
+/* -------------------------------- */
+/* Deploy status                    */
+/* -------------------------------- */
+
+.status-route-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.status-route {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 16px;
+  background: rgba(47, 93, 80, 0.06);
+  border: 1px solid rgba(47, 93, 80, 0.08);
+}
+
+.status-route strong {
+  color: var(--accent);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.status-route a {
+  overflow-wrap: anywhere;
+  font-weight: 650;
+}
+
+.status-route span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 520px) {
+  .status-route {
+    padding: 0.7rem;
+  }
+
+  .status-route span {
+    font-size: 0.86rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `public/status.json` as a fallback machine-readable status file
- Updates `scripts/deploy.sh` to require `dist/status.json` in build output
- Adds `/status.json` to live validation routes
- Writes an updated `dist/status.json` after successful live validation
- Syncs the generated `status.json` to the live webroot
- Updates `/status/` to fetch `/status.json` and show the latest verified deploy status
- Adds CSS for readable route status cards

## Validation
- `bash -n scripts/deploy.sh` → passed
- `git diff --check` → passed
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 20 pages generated

## Risk
Medium-low. Touches deploy script, status page, CSS and fallback public data. The deploy script still fails closed: it only writes live status after successful route validation, and still blocks deploy on dirty working tree or non-main branch.