### PR TITLE
Fix deploy status JSON parsing

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -108,9 +108,14 @@ echo "=== Write deploy status ==="
 CHECKED_AT="$(date -Iseconds)"
 COMMIT="$(git rev-parse --short HEAD)"
 
-python3 - <<PYJSON
+STATUS_ROUTES_JSON_ARRAY="[$STATUS_ROUTES_JSON]"
+
+STATUS_ROUTES_JSON_ARRAY="$STATUS_ROUTES_JSON_ARRAY" python3 - <<PYJSON
 import json
+import os
 from pathlib import Path
+
+routes = json.loads(os.environ["STATUS_ROUTES_JSON_ARRAY"])
 
 status = {
     "site": "innosocia.dk",
@@ -119,7 +124,7 @@ status = {
     "branch": "$BRANCH",
     "commit": "$COMMIT",
     "ok": True,
-    "routes": [$STATUS_ROUTES_JSON],
+    "routes": routes,
     "note": "Generated after successful live validation.",
 }
 


### PR DESCRIPTION
## Summary
- Fixes deploy status generation after live validation
- Sends the collected route JSON array through an environment variable
- Parses it with `json.loads()` instead of embedding JSON directly as Python code
- Prevents the `NameError: name 'true' is not defined` failure caused by JSON booleans inside Python literals

## Validation
- `bash -n scripts/deploy.sh` → passed
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 20 pages generated

## Risk
Low. Deploy-script-only hotfix. It does not change site content, styling, routes, proxy config, or build config.