### PR TITLE
Add app availability status

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -19,6 +19,12 @@ const apps = defineCollection({
 
     repoUrl: z.string().url().optional(),
     license: z.string().optional(),
+    availabilityLabel: z.string().optional(),
+    availabilityText: z.string().optional(),
+    primaryUrl: z.string().url().optional(),
+    primaryActionLabel: z.string().optional(),
+    downloadStatus: z.string().optional(),
+    nextStep: z.string().optional(),
     screenshots: z.array(z.object({
       src: z.string(),
       alt: z.string(),

--- a/src/content/apps/sovereign-strength.md
+++ b/src/content/apps/sovereign-strength.md
@@ -27,6 +27,13 @@ relatedApps:
 repoUrl: "https://github.com/jakobbskov/sovereign-strength"
 license: "MIT"
 
+availabilityLabel: "Kan prøves nu"
+availabilityText: "Sovereign Strength kan prøves som beta på strength.innosocia.dk."
+primaryUrl: "https://strength.innosocia.dk/"
+primaryActionLabel: "Prøv betaen"
+downloadStatus: "Der er ikke frigivet en offentlig APK eller app-build endnu."
+nextStep: "Næste skridt er at gøre status, programmer og brugerflow endnu tydeligere."
+
 screenshots:
   - src: "/images/apps/sovereign-strength/overview-history.png"
     alt: "Historik og ugentlig rytme i Sovereign Strength"

--- a/src/pages/apps/[slug].astro
+++ b/src/pages/apps/[slug].astro
@@ -58,6 +58,49 @@ const pageImage = "https://innosocia.dk/social-preview-default.png";
     </div>
   </section>
 
+  {(app.data.availabilityText || app.data.downloadStatus || app.data.nextStep || app.data.primaryUrl) && (
+    <section class="section">
+      <div class="wrapper">
+        <div class="section-head">
+          <h2>Kort status</h2>
+          <p class="muted">
+            Hvad kan man gøre med appen lige nu?
+          </p>
+        </div>
+
+        <div class="grid grid-3">
+          {app.data.availabilityText && (
+            <div class="card">
+              <h3>{app.data.availabilityLabel || "Status"}</h3>
+              <p class="muted">{app.data.availabilityText}</p>
+              {app.data.primaryUrl && (
+                <p>
+                  <a href={app.data.primaryUrl} target="_blank" rel="noopener noreferrer">
+                    {app.data.primaryActionLabel || "Åbn app"}
+                  </a>
+                </p>
+              )}
+            </div>
+          )}
+
+          {app.data.downloadStatus && (
+            <div class="card">
+              <h3>Download</h3>
+              <p class="muted">{app.data.downloadStatus}</p>
+            </div>
+          )}
+
+          {app.data.nextStep && (
+            <div class="card">
+              <h3>Næste skridt</h3>
+              <p class="muted">{app.data.nextStep}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )}
+
   {app.data.screenshots?.length > 0 && (
     <section class="section">
       <div class="wrapper">


### PR DESCRIPTION
## Summary
- Adds optional app availability fields to the app content schema
- Adds Sovereign Strength availability data:
  - beta can be tried at `strength.innosocia.dk`
  - no public APK/build yet
  - next step text
- Adds a `Kort status` section to app detail pages when availability data exists
- Keeps other app pages unchanged because all new fields are optional

## Validation
- `git diff --check` → passed
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 20 pages generated
- Manual local visual review of `/apps/sovereign-strength/` → looked good

## Risk
Low-medium. Touches app schema, one content file and app detail page rendering. No deploy script, proxy config, routing or global layout changes.