### PR TITLE
Show app availability on overview cards

### DIFF
--- a/src/components/AppCard.astro
+++ b/src/components/AppCard.astro
@@ -12,8 +12,15 @@ const { app } = Astro.props;
   <p>{app.data.tagline}</p>
   <p class="muted">{app.data.summary}</p>
 
-  <div class="meta">
-    <span>Status: {app.data.status}</span>
-    <span>Opdateret: {app.data.updatedAt}</span>
-  </div>
+  {app.data.availabilityLabel && (
+    <p class="status-card-strong">{app.data.availabilityLabel}</p>
+  )}
+
+  {app.data.primaryUrl && (
+    <p>
+      <a href={app.data.primaryUrl} target="_blank" rel="noopener noreferrer">
+        {app.data.primaryActionLabel || "Åbn app"}
+      </a>
+    </p>
+  )}
 </article>


### PR DESCRIPTION
## Summary
- Updates `AppCard.astro` so app overview cards can show availability actions
- Shows `availabilityLabel` and `primaryActionLabel` when present
- Removes generic `Status: prototype` and `Opdateret` metadata from overview cards
- Keeps Finance and Planta clean because they do not currently have availability actions

## Validation
- `git diff --check` → passed
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 20 pages generated
- Manual local visual review of `/apps/` → looked good

## Risk
Low. Component-only change. No schema, content, deploy script, routing, proxy config, or global layout changes.