### PR TITLE
Add app data and privacy context

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,6 +25,9 @@ const apps = defineCollection({
     primaryActionLabel: z.string().optional(),
     downloadStatus: z.string().optional(),
     nextStep: z.string().optional(),
+    dataPrivacyTitle: z.string().optional(),
+    dataPrivacyText: z.string().optional(),
+    dataPrivacyPoints: z.array(z.string()).default([]),
     screenshots: z.array(z.object({
       src: z.string(),
       alt: z.string(),

--- a/src/content/apps/sovereign-finance.md
+++ b/src/content/apps/sovereign-finance.md
@@ -32,7 +32,7 @@ Sovereign Finance er et forsøg på at bygge et økonomiværktøj, der ikke gør
 
 Mange økonomiapps lover overblik, men leverer i praksis dashboards, abonnementstænkning og pæne visualiseringer, som ikke nødvendigvis gør brugeren klogere. De viser noget. De forklarer ikke nødvendigvis noget.
 
-## Formål
+### Formål
 
 Formålet er at gøre personlig økonomi mere læsbar.
 
@@ -40,7 +40,7 @@ Det handler ikke kun om at registrere poster eller holde styr på budgetlinjer. 
 
 Et godt økonomiværktøj bør ikke bare vise data. Det bør hjælpe brugeren med at udvikle dømmekraft.
 
-## Hvilket problem appen reagerer på
+### Hvilket problem appen reagerer på
 
 Personlig økonomi er for mange blevet reduceret til en blanding af:
 - kontoudtog
@@ -53,7 +53,7 @@ Det giver information, men ikke nødvendigvis forståelse.
 
 Sovereign Finance forsøger derfor at samle overblik, prioritering og refleksion i ét roligere system.
 
-## Hvad appen skal kunne på sigt
+### Hvad appen skal kunne på sigt
 
 På sigt bør Sovereign Finance kunne understøtte:
 - budget og frie midler
@@ -65,7 +65,7 @@ På sigt bør Sovereign Finance kunne understøtte:
 
 Det afgørende er ikke flest mulige features. Det afgørende er, at logikken bag dem er tydelig.
 
-## Hvorfor den passer ind i Innosocia
+### Hvorfor den passer ind i Innosocia
 
 Sovereign Finance er ikke bare en økonomiapp. Den er et eksempel på den type værktøj Innosocia forsøger at udvikle:
 

--- a/src/content/apps/sovereign-planta.md
+++ b/src/content/apps/sovereign-planta.md
@@ -32,13 +32,13 @@ Sovereign Planta er et forsøg på at gøre plantepleje mere systematisk uden at
 
 Mange planteapps lover hjælp, men ender med at blive enten overdesignede, for generiske eller afhængige af platformfunktioner, som ikke gør selve plejen bedre. De producerer notifikationer, men ikke nødvendigvis bedre observation.
 
-## Formål
+### Formål
 
 Formålet er at skabe et roligt værktøj til overblik, rytmer og observationer.
 
 Appen skal ikke gøre plantepleje til et præstationsprojekt. Den skal gøre det lettere at opdage mønstre og handle i tide, uden at brugeren skal holde hele systemet i hovedet.
 
-## Hvilket problem appen reagerer på
+### Hvilket problem appen reagerer på
 
 Plantepleje i hverdagen falder ofte mellem intuition og glemsel.
 
@@ -50,7 +50,7 @@ Man husker lidt, gætter lidt og improviserer lidt. Det virker, lige indtil det 
 
 Sovereign Planta forsøger at samle den viden i en enkel og lokal praksis.
 
-## Hvad appen skal kunne på sigt
+### Hvad appen skal kunne på sigt
 
 På sigt bør appen kunne understøtte:
 - profiler for arter og individuelle planter
@@ -62,7 +62,7 @@ På sigt bør appen kunne understøtte:
 
 Det er mindre vigtigt at gøre appen “smart” end at gøre den brugbar over tid.
 
-## Hvorfor den passer ind i Innosocia
+### Hvorfor den passer ind i Innosocia
 
 Sovereign Planta er et eksempel på rolig teknologi i lille skala.
 

--- a/src/content/apps/sovereign-strength.md
+++ b/src/content/apps/sovereign-strength.md
@@ -34,6 +34,13 @@ primaryActionLabel: "Prøv betaen"
 downloadStatus: "Der er ikke frigivet en offentlig APK eller app-build endnu."
 nextStep: "Næste skridt er at gøre status, programmer og brugerflow endnu tydeligere."
 
+dataPrivacyTitle: "Data og privatliv"
+dataPrivacyText: "Sovereign Strength er bygget med local-first retning. Målet er, at træningsdata skal være forståelige, flytbare og så lidt afhængige af eksterne platforme som muligt."
+dataPrivacyPoints:
+  - "Betaen kører som webapp, men retningen er lav platformafhængighed."
+  - "Træningsdata skal bruges til progression og overblik, ikke til fastholdelse."
+  - "Appens logik skal kunne forklares uden skjulte anbefalinger."
+
 screenshots:
   - src: "/images/apps/sovereign-strength/overview-history.png"
     alt: "Historik og ugentlig rytme i Sovereign Strength"
@@ -53,7 +60,7 @@ Sovereign Strength er et forsøg på at bygge en træningsapp, der tager struktu
 
 Mange træningsapps er enten for overfladiske eller for oppustede. De lover optimering, men leverer ofte bare logning, badges og visuel aktivitet, som ikke nødvendigvis gør træningen mere sammenhængende.
 
-## Formål
+### Formål
 
 Formålet er at samle træningshistorik, belastning, refleksion og progression i et værktøj, der er læsbart og brugbart over tid.
 
@@ -63,7 +70,7 @@ Appen skal ikke bare registrere, hvad der skete. Den skal hjælpe brugeren med a
 - er belastningen realistisk?
 - er der brug for justering, vedligehold eller optrapning?
 
-## Hvilket problem appen reagerer på
+### Hvilket problem appen reagerer på
 
 Træning bliver ofte unødigt fragmenteret.
 
@@ -83,7 +90,7 @@ Sovereign Strength forsøger derfor at bygge et værktøj med:
 - forklarbar beslutningslogik
 - lokal kontrol over egne data
 
-## Hvad appen skal kunne på sigt
+### Hvad appen skal kunne på sigt
 
 På sigt bør appen kunne understøtte:
 - øvelseslogik
@@ -95,7 +102,7 @@ På sigt bør appen kunne understøtte:
 
 Alt sammen uden at brugeren behøver overlade sin træningspraksis til en black box.
 
-## Hvorfor den passer ind i Innosocia
+### Hvorfor den passer ind i Innosocia
 
 Sovereign Strength handler i sidste ende ikke kun om træning.
 

--- a/src/pages/apps/[slug].astro
+++ b/src/pages/apps/[slug].astro
@@ -130,8 +130,27 @@ const pageImage = "https://innosocia.dk/social-preview-default.png";
     </section>
   )}
 
+  {(app.data.dataPrivacyText || app.data.dataPrivacyPoints?.length > 0) && (
+    <section class="section">
+      <div class="reading">
+        <h2>{app.data.dataPrivacyTitle || "Data og privatliv"}</h2>
+
+        {app.data.dataPrivacyText && (
+          <p>{app.data.dataPrivacyText}</p>
+        )}
+
+        {app.data.dataPrivacyPoints?.length > 0 && (
+          <ul>
+            {app.data.dataPrivacyPoints.map((point) => <li>{point}</li>)}
+          </ul>
+        )}
+      </div>
+    </section>
+  )}
+
   <section class="section">
     <div class="reading">
+      <h2>Om appen</h2>
       <Content />
     </div>
   </section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1672,3 +1672,28 @@ h3 {
     border-radius: 18px;
   }
 }
+
+/* -------------------------------- */
+/* Reading hierarchy                */
+/* -------------------------------- */
+
+.reading h3 {
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  font-size: clamp(1.35rem, 4vw, 1.7rem);
+  line-height: 1.15;
+}
+
+.reading h2 + h3,
+.reading p + h3,
+.reading ul + h3,
+.reading ol + h3 {
+  margin-top: 2.2rem;
+}
+
+@media (max-width: 520px) {
+  .reading h3 {
+    margin-top: 1.8rem;
+    margin-bottom: 0.65rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds optional data/privacy fields to the app content schema
- Adds a `Data og privatliv` section for Sovereign Strength
- Explains the current beta context and local-first direction in plain language
- Adds an `Om appen` heading before the long app description
- Demotes app Markdown section headings from `h2` to `h3` for better hierarchy
- Adds reading `h3` spacing so the app pages are easier to scan on mobile

## Validation
- `git diff --check` → passed
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 20 pages generated
- Manual mobile visual review of `/apps/sovereign-strength/` → looked better after hierarchy and spacing fixes

## Risk
Low-medium. Touches app schema, app content, app detail rendering and global reading heading styles. No deploy script, routing, proxy config or layout changes.