### PR TITLE
Add status context for all apps

### DIFF
--- a/src/content/apps/sovereign-finance.md
+++ b/src/content/apps/sovereign-finance.md
@@ -26,6 +26,17 @@ relatedApps:
 
 repoUrl: "https://github.com/jakobbskov/sovereign-finance"
 license: "MIT"
+
+availabilityLabel: "Ikke offentligt prøvbar endnu"
+availabilityText: "Sovereign Finance er et prototype- og konceptspor. Der er ikke en offentlig demo endnu."
+downloadStatus: "Der er ikke frigivet en offentlig build eller download endnu."
+nextStep: "Næste skridt er at afklare første brugbare prototype og vise tydeligere, hvad appen skal kunne."
+dataPrivacyTitle: "Data og privatliv"
+dataPrivacyText: "Sovereign Finance bygger på samme retning som resten af Sovereign-apps: økonomidata skal være forståelige, flytbare og så lidt afhængige af eksterne platforme som muligt."
+dataPrivacyPoints:
+  - "Der er ikke en offentlig version med brugerdata endnu."
+  - "Økonomidata skal behandles som følsomme personlige oplysninger."
+  - "Målet er lokal eller selvkontrolleret datalagring frem for unødvendig platformslåsning."
 ---
 
 Sovereign Finance er et forsøg på at bygge et økonomiværktøj, der ikke gør brugeren mere afhængig, mere forvirret eller mere styret af andres logik.

--- a/src/content/apps/sovereign-planta.md
+++ b/src/content/apps/sovereign-planta.md
@@ -26,6 +26,17 @@ relatedApps:
 
 repoUrl: "https://github.com/jakobbskov/sovereign-planta"
 license: "MIT"
+
+availabilityLabel: "Ikke offentligt prøvbar endnu"
+availabilityText: "Sovereign Planta er et prototype- og konceptspor. Der er ikke en offentlig demo endnu."
+downloadStatus: "Der er ikke frigivet en offentlig build eller download endnu."
+nextStep: "Næste skridt er at afklare første enkle prototype for planter, rytmer og observationer."
+dataPrivacyTitle: "Data og privatliv"
+dataPrivacyText: "Sovereign Planta er tænkt som et roligt værktøj, hvor data om planter, placeringer og plejehistorik holdes enkelt og forståeligt."
+dataPrivacyPoints:
+  - "Der er ikke en offentlig version med brugerdata endnu."
+  - "Plejedata skal bruges til overblik og observation, ikke til støjende notifikationer."
+  - "Målet er lokal eller selvkontrolleret datalagring frem for unødvendig platformslåsning."
 ---
 
 Sovereign Planta er et forsøg på at gøre plantepleje mere systematisk uden at gøre den mere stressende.


### PR DESCRIPTION
## Summary
- Adds clear availability/status context for Sovereign Finance
- Adds clear availability/status context for Sovereign Planta
- Makes unavailable apps explicit instead of leaving visitors to infer status
- Adds download status, next step and data/privacy context for both apps
- Keeps app overview actions unchanged because Finance and Planta do not have public demos yet

## Validation
- `git diff --check` → passed
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 20 pages generated
- Manual local visual review of `/apps/sovereign-finance/`, `/apps/sovereign-planta/` and `/apps/` → worked as expected

## Risk
Low. Content-only change to two app Markdown files. No schema, rendering, CSS, deploy script, routing or proxy config changes.