### PR TITLE
Add collaboration page

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -18,6 +18,7 @@
       <p><a href="/downloads/">Downloads</a></p>
       <p><a href="/architecture/">Architecture</a></p>
       <p><a href="/status/">Status</a></p>
+      <p><a href="/samarbejde/">Samarbejde</a></p>
     </div>
   </div>
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,6 +13,7 @@
       <a href="/architecture/">Architecture</a>
       <a href="/status/">Status</a>
       <a href="/om/">Om</a>
+      <a href="/samarbejde/">Samarbejde</a>
       <a href="/kontakt/">Kontakt</a>
     </nav>
   </div>

--- a/src/pages/samarbejde.astro
+++ b/src/pages/samarbejde.astro
@@ -1,0 +1,186 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout
+  title="Samarbejde | Innosocia"
+  description="Samarbejde med Innosocia om digital suverænitet, local-first værktøjer, open source, AI og mere robuste digitale arbejdsgange."
+>
+  <section class="hero">
+    <div class="wrapper">
+      <p class="eyebrow">Samarbejde</p>
+      <h1>For organisationer, der vil bygge mere forståelige digitale løsninger</h1>
+      <p class="muted" style="max-width: 62ch;">
+        Innosocia samarbejder gerne med kommuner, NGO’er, foreninger og mindre organisationer,
+        der vil undersøge mere robuste, gennemsigtige og mindre platformafhængige digitale løsninger.
+      </p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="wrapper">
+      <div class="section-head">
+        <h2>Hvem siden er for</h2>
+        <p class="muted">
+          Samarbejde giver mest mening, når der er et konkret problem, en praksis eller en arbejdsgang at tage afsæt i.
+        </p>
+      </div>
+
+      <div class="grid grid-3">
+        <div class="card">
+          <h3>Kommuner og offentlige miljøer</h3>
+          <p class="muted">
+            Særligt hvor digitalisering, dokumentation, velfærdsteknologi eller AI skal gøres mere praksisnært og forståeligt.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3>NGO’er og foreninger</h3>
+          <p class="muted">
+            Organisationer der har brug for enkle digitale værktøjer, bedre overblik eller mere kontrol over data og arbejdsgange.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3>Små teams og faglige fællesskaber</h3>
+          <p class="muted">
+            Miljøer der vil afprøve små prototyper, rydde op i digitale processer eller bygge noget, der kan forklares uden konsulenttåge.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="reading">
+      <h2>Hvad et samarbejde kan handle om</h2>
+
+      <p>
+        Innosocia er ikke tænkt som en stor leverandørpakke. Det giver mere mening som et udviklings- og sparringsspor,
+        hvor digitale problemer undersøges tæt på praksis.
+      </p>
+
+      <ul>
+        <li>local-first værktøjer og små open source-prototyper</li>
+        <li>mere forståelige arbejdsgange og dokumentationsflows</li>
+        <li>AI og automatisering, der understøtter dømmekraft i stedet for at erstatte den</li>
+        <li>self-hosting, Nextcloud og enklere digital infrastruktur</li>
+        <li>workshops om digital suverænitet, rolig teknologi og platformafhængighed</li>
+        <li>kritisk sparring på digitale projekter, hvor løsningen er ved at blive større end problemet</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="wrapper">
+      <div class="section-head">
+        <h2>Mulige samarbejdsformer</h2>
+        <p class="muted">
+          Små, afgrænsede forløb er ofte bedre end store planer med for mange slides og for lidt virkelighed.
+        </p>
+      </div>
+
+      <div class="grid grid-2">
+        <div class="card">
+          <h3>Afklaring</h3>
+          <p class="muted">
+            Kort analyse af et digitalt problem, en arbejdsgang eller et teknologisk valg.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3>Workshop</h3>
+          <p class="muted">
+            Fælles arbejde med behov, principper, risici og mulige løsninger.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3>Prototype</h3>
+          <p class="muted">
+            En lille, konkret løsning eller demonstrator, der kan testes før noget gøres større.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3>Sparring</h3>
+          <p class="muted">
+            Kritisk og praktisk sparring på digitale initiativer, AI-brug, open source eller lokal infrastruktur.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="reading">
+      <h2>Hvad Innosocia ikke er</h2>
+
+      <p>
+        Innosocia er ikke endnu et sted, hvor alle problemer løses med et dashboard,
+        et abonnement eller en AI-knap med tvivlsom selvtillid.
+      </p>
+
+      <ul>
+        <li>ikke en standard SaaS-leverandør</li>
+        <li>ikke et bureau for hurtige kampagnesider</li>
+        <li>ikke et konsulenthus med metodepakker i blank indpakning</li>
+        <li>ikke et løfte om magisk AI-transformation</li>
+      </ul>
+
+      <p>
+        Pointen er at bygge og tænke mindre, klarere og mere kontrollerbart, før systemerne bliver så store,
+        at ingen længere kan forklare, hvorfor de findes.
+      </p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="wrapper">
+      <div class="section-head">
+        <h2>Eksempler på relevante spor</h2>
+        <p class="muted">
+          Samarbejde kan tage afsæt i både eksisterende prototyper og nye praktiske behov.
+        </p>
+      </div>
+
+      <div class="grid grid-3">
+        <div class="card">
+          <h3><a href="/apps/sovereign-strength/">Sovereign Strength</a></h3>
+          <p class="muted">
+            En beta-app for forklarbar træning, status, progression og local-first retning.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3><a href="/projekter/sovereign-suite/">Sovereign Suite</a></h3>
+          <p class="muted">
+            Et samlet spor for små, forklarbare værktøjer med lavere platformafhængighed.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3><a href="/principper/">Principper</a></h3>
+          <p class="muted">
+            Grundidéerne bag rolig teknologi, digital suverænitet og local-first software.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="wrapper">
+      <div class="card">
+        <h2>Tag kontakt</h2>
+        <p class="muted">
+          Har du et konkret problem, en idé til et pilotforløb eller et behov for sparring,
+          er kontakt-siden det bedste sted at starte.
+        </p>
+        <p>
+          <a class="button primary" href="/kontakt/">Kontakt Innosocia</a>
+        </p>
+      </div>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Adds a new `/samarbejde/` page for organizations and partners
- Explains who collaboration is relevant for: municipalities, NGOs, associations, small teams and professional communities
- Describes possible collaboration themes such as local-first tools, open source prototypes, AI/automation, Nextcloud/self-hosting and workflow clarification
- Adds concrete collaboration formats: clarification, workshop, prototype and sparring
- Clarifies what Innosocia is not, to avoid SaaS/vendor/AI-magic positioning
- Adds links from header and footer
- Ends with a clear contact CTA

## Validation
- `git diff --check` → passed
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 21 pages generated
- Manual local visual review of `/samarbejde/` → looked good

## Risk
Low-medium. Adds a new public content page and navigation links. No schema, deploy script, proxy config, runtime logic or route config changes.