### PR TITLE
Simplify primary navigation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,13 +7,9 @@
       <a href="/ideer/">Idéer</a>
       <a href="/projekter/">Projekter</a>
       <a href="/principper/">Principper</a>
-      <a href="/now/">Nu</a>
-      <a href="/build-log/">Build log</a>
-      <a href="/downloads/">Downloads</a>
-      <a href="/architecture/">Architecture</a>
       <a href="/status/">Status</a>
-      <a href="/om/">Om</a>
       <a href="/samarbejde/">Samarbejde</a>
+      <a href="/om/">Om</a>
       <a href="/kontakt/">Kontakt</a>
     </nav>
   </div>


### PR DESCRIPTION
## Summary
- Simplifies the primary header navigation
- Removes lower-priority support/technical pages from the main nav:
  - `/now/`
  - `/build-log/`
  - `/downloads/`
  - `/architecture/`
- Keeps the pages available through footer links, sitemap and direct URLs
- Keeps the main navigation focused on the public user journey:
  - Apps
  - Idéer
  - Projekter
  - Principper
  - Status
  - Samarbejde
  - Om
  - Kontakt

## Validation
- `git diff --check` → passed
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 21 pages generated
- Manual mobile visual review of the homepage header → looked much calmer

## Risk
Low. Header-only navigation cleanup. No pages deleted, no redirects, no noindex changes, no deploy script, routing, schema, proxy config or runtime logic changes.

## Related issue
Part of #23: Audit and clean up old indexed pages that conflict with current positioning.