### PR TITLE
Clarify architecture page positioning

### DIFF
--- a/src/pages/architecture.astro
+++ b/src/pages/architecture.astro
@@ -3,18 +3,32 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout
-  title="Architecture | Innosocia"
-  description="Teknisk arkitektur og driftsprincipper bag Innosocia."
+  title="Arkitektur | Innosocia"
+  description="Teknisk overblik over Innosocias enkle self-hosted arkitektur, apps, noder og driftsprincipper."
 >
   <section class="hero">
     <div class="wrapper">
-      <p class="eyebrow">Architecture</p>
+      <p class="eyebrow">Arkitektur</p>
       <h1>Den tekniske struktur bag Innosocia</h1>
       <p class="muted" style="max-width: 62ch;">
-        Innosocia er ikke bygget som en klassisk cloud-platform. Projektet hviler på en
-        lille, selvhostet og bevidst enkel arkitektur med fokus på local-first principper,
-        tydelige noder og lav platformafhængighed.
+        Innosocia er bygget som et lille, selvhostet økosystem. Pointen er ikke at gøre infrastrukturen imponerende,
+        men at gøre den forståelig, flytbar og mulig at vedligeholde over tid.
       </p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="wrapper">
+      <div class="card">
+        <h2>Hvorfor arkitekturen betyder noget</h2>
+        <p class="muted">
+          Arkitekturen er en del af projektets troværdighed. Hvis Innosocia taler om digital suverænitet,
+          lav afhængighed og local-first værktøjer, skal den tekniske struktur også pege i den retning.
+        </p>
+        <p>
+          <a href="/principper/">Læs principperne bag →</a>
+        </p>
+      </div>
     </div>
   </section>
 
@@ -23,8 +37,8 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       <div class="architecture-diagram">
         <div class="architecture-diagram__layer">
           <div class="architecture-node architecture-node--wide">
-            <strong>Internet / domæner</strong>
-            <span>innosocia.dk · apps · dokumentation · offentlige indgange</span>
+            <strong>Offentlige indgange</strong>
+            <span>innosocia.dk · apps · status · dokumentation · samarbejde</span>
           </div>
         </div>
 
@@ -32,8 +46,8 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
         <div class="architecture-diagram__layer">
           <div class="architecture-node architecture-node--wide">
-            <strong>Reverse proxy / routing</strong>
-            <span>Styrer trafik, endpoints og adskillelse mellem site, apps og tjenester</span>
+            <strong>Routing og adgang</strong>
+            <span>Reverse proxy, HTTPS og adskillelse mellem site, apps og tjenester</span>
           </div>
         </div>
 
@@ -42,12 +56,12 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         <div class="architecture-diagram__grid">
           <div class="architecture-node">
             <strong>Raspberry Pi</strong>
-            <span>Edge node · Nextcloud · personligt fil- og platformslag</span>
+            <span>Edge node · Nextcloud · filer · personligt platformslag</span>
           </div>
 
           <div class="architecture-node">
             <strong>Beelink mini-server</strong>
-            <span>App node · apps · eksperimenter · docker-baserede services</span>
+            <span>App node · website · prototyper · Docker-baserede services</span>
           </div>
         </div>
 
@@ -56,78 +70,58 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         <div class="architecture-diagram__grid">
           <div class="architecture-node">
             <strong>Sovereign Strength</strong>
-            <span>Træning · logik · progression</span>
+            <span>Beta-app · træning · status · progression</span>
           </div>
 
           <div class="architecture-node">
             <strong>Sovereign Finance</strong>
-            <span>Økonomi · overblik · beslutningsstøtte</span>
+            <span>Prototype-spor · økonomi · overblik · beslutningsstøtte</span>
           </div>
 
           <div class="architecture-node">
             <strong>Sovereign Planta</strong>
-            <span>Plantepleje · rytmer · observation</span>
+            <span>Prototype-spor · planter · rytmer · observation</span>
           </div>
         </div>
       </div>
-    </div>
-  </section>
-
-  <section class="section">
-    <div class="reading">
-      <h2>Hvorfor arkitekturen ser sådan ud</h2>
-
-      <p>
-        Innosocia er bygget som et lille økosystem af noder og tjenester i stedet for som én
-        stor, central platform. Det gør det lettere at forstå driften, flytte dele rundt og
-        eksperimentere uden at hele systemet bliver skrøbeligt.
-      </p>
-
-      <p>
-        Det er ikke en maksimalistisk infrastruktur. Tværtimod. Pointen er at holde systemet
-        lille nok til at kunne vedligeholdes og gennemskues, men stærkt nok til at bære både
-        apps, site og dokumentation.
-      </p>
     </div>
   </section>
 
   <section class="section">
     <div class="wrapper">
       <div class="section-head">
-        <h2>Noder og roller</h2>
-        <p class="muted">Hver del af systemet har en tydelig funktion.</p>
+        <h2>Hoveddele</h2>
+        <p class="muted">
+          Hver del har en enkel rolle. Det er hele pointen, selv om softwarebranchen ofte virker personligt fornærmet over enkelhed.
+        </p>
       </div>
 
       <div class="grid grid-2">
         <div class="card">
-          <h3>Raspberry Pi</h3>
+          <h3>Offentligt site</h3>
           <p class="muted">
-            Fungerer som edge node og personligt platformslag med fokus på filer,
-            Nextcloud og stabil, lokal infrastruktur.
+            Innosocia.dk fungerer som offentlig indgang til apps, idéer, projekter, principper, status og samarbejde.
           </p>
         </div>
 
         <div class="card">
-          <h3>Beelink mini-server</h3>
+          <h3>Apps</h3>
           <p class="muted">
-            Fungerer som applikationsnode til apps, eksperimenter og services, hvor der er
-            behov for mere fleksibilitet og flere ressourcer.
+            Apps ligger som egne spor med tydelig status, link til kode, screenshots hvor relevant og klar forklaring af data og privatliv.
           </p>
         </div>
 
         <div class="card">
-          <h3>Reverse proxy</h3>
+          <h3>Self-hosting</h3>
           <p class="muted">
-            Skaber et samlet offentligt lag udadtil og holder styr på routing mellem site,
-            apps og eventuelle tjeneste-endpoints.
+            Projektet bygger på en lille selvhostet infrastruktur med Raspberry Pi, mini-server og kontrollerede tjenester.
           </p>
         </div>
 
         <div class="card">
-          <h3>Apps og site</h3>
+          <h3>Dokumentation</h3>
           <p class="muted">
-            Innosocia.dk fungerer som front door, mens apps og dokumenter lever i deres egne
-            spor og noder under samme overordnede struktur.
+            Sitet fungerer også som dokumentation for retning, status, arkitektur og udviklingshistorik.
           </p>
         </div>
       </div>
@@ -136,28 +130,55 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
   <section class="section">
     <div class="reading">
-      <h2>Arkitekturprincipper</h2>
+      <h2>Driftsprincipper</h2>
+
+      <p>
+        Arkitekturen er bevidst lille. Det gør den lettere at forstå, flytte, fejlfinde og ændre.
+        Målet er ikke maksimal kompleksitet, men tilstrækkelig robusthed.
+      </p>
 
       <ul>
-        <li>Small systems over large platform stacks</li>
-        <li>Local-first hvor det giver mening</li>
-        <li>Lav afhængighed af eksterne tjenester</li>
-        <li>Tydelig adskillelse mellem roller og noder</li>
-        <li>Mulighed for gradvis udvidelse uden total ombygning</li>
+        <li>små systemer før store platformstacks</li>
+        <li>local-first hvor det giver praktisk mening</li>
+        <li>lav afhængighed af eksterne tjenester</li>
+        <li>tydelig adskillelse mellem site, apps, filer og tjenester</li>
+        <li>mulighed for gradvis udvidelse uden total ombygning</li>
+        <li>drift der kan forklares uden leverandørmystik</li>
       </ul>
     </div>
   </section>
 
   <section class="section">
-    <div class="reading">
-      <h2>Hvad det peger frem imod</h2>
+    <div class="wrapper">
+      <div class="section-head">
+        <h2>Hvordan det hænger sammen med resten af sitet</h2>
+        <p class="muted">
+          Arkitekturen er ikke en isoleret teknisk detalje. Den understøtter projektets principper og apps.
+        </p>
+      </div>
 
-      <p>
-        På sigt kan denne struktur udvides med flere apps, offentlige filrum, downloads,
-        statusfeeds og eventuelt flere noder. Men udgangspunktet forbliver det samme:
-        små robuste systemer der kan forstås, drives og ændres uden at blive fanget i
-        unødig kompleksitet.
-      </p>
+      <div class="grid grid-3">
+        <div class="card">
+          <h3><a href="/apps/">Apps</a></h3>
+          <p class="muted">
+            De konkrete værktøjer, der viser hvordan principperne omsættes til software.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3><a href="/status/">Status</a></h3>
+          <p class="muted">
+            Offentlig status for ændringer, deploy og hvad der faktisk er flyttet på sitet.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3><a href="/downloads/">Ressourcer</a></h3>
+          <p class="muted">
+            Ressourcer, dokumentation og download-status, når filer eller builds frigives.
+          </p>
+        </div>
+      </div>
     </div>
   </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Rewrites `/architecture/` so it works as understandable technical proof
- Changes title/framing from `Architecture` to `Arkitektur`
- Explains why the architecture matters for digital sovereignty, low dependency and local-first tools
- Keeps the architecture diagram but makes labels clearer
- Reframes system parts as public site, apps, self-hosting and documentation
- Rewrites operating principles in clearer Danish
- Adds links to apps, status and resources

## Validation
- `git diff --check` → passed
- `npm audit` → 0 vulnerabilities
- `npm run build` → successful Astro static build, 21 pages generated
- Manual local visual review of `/architecture/` → looked good

## Risk
Low. Content-only rewrite of one support page. No schema, deploy script, routing, proxy config, runtime logic or layout changes.

## Related issue
Part of #23: Audit and clean up old indexed pages that conflict with current positioning.