### PR TITLE
Clarify homepage explanation and public language

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,7 +3,7 @@
     <div>
       <p><strong>Innosocia</strong></p>
       <p class="muted">
-        Rolig teknologi, local-first værktøjer og digital suverænitet.
+        Forståelige værktøjer, local-first retning og digital suverænitet.
       </p>
       <p class="muted">
         Et projekt af Jakob Skov.

--- a/src/components/HeroSystemCard.astro
+++ b/src/components/HeroSystemCard.astro
@@ -34,6 +34,6 @@
     <div class="hero-system-panel__pill">local-first</div>
     <div class="hero-system-panel__pill">open repos</div>
     <div class="hero-system-panel__pill">egen drift</div>
-    <div class="hero-system-panel__pill">rolig teknologi</div>
+    <div class="hero-system-panel__pill">mindre støj</div>
   </div>
 </div>

--- a/src/content/apps/sovereign-planta.md
+++ b/src/content/apps/sovereign-planta.md
@@ -75,7 +75,7 @@ Det er mindre vigtigt at gøre appen “smart” end at gøre den brugbar over t
 
 ### Hvorfor den passer ind i Innosocia
 
-Sovereign Planta er et eksempel på rolig teknologi i lille skala.
+Sovereign Planta er et eksempel på et lille værktøj, der skal hjælpe uden at forstyrre mere end nødvendigt.
 
 Den forsøger ikke at overtage praksissen. Den forsøger at støtte den.
 

--- a/src/pages/apps/index.astro
+++ b/src/pages/apps/index.astro
@@ -25,7 +25,7 @@ const ideaApps = apps.filter((app) => app.data.status === "idea");
       <h1>Sovereign-apps og værktøjer med rygrad</h1>
       <p class="muted">
         Apps-siden samler værktøjer udviklet med fokus på local-first software,
-        forståelig logik, lav platformafhængighed og mere rolig teknologi.
+        forståelig logik, lav platformafhængighed og mindre digital støj.
       </p>
       <p class="muted">
         De findes ikke for at fylde endnu et dashboard med funktioner, men for at
@@ -62,7 +62,7 @@ const ideaApps = apps.filter((app) => app.data.status === "idea");
         </div>
 
         <div class="card">
-          <h3>Rolig teknologi</h3>
+          <h3>Mindre digital støj</h3>
           <p class="muted">
             Mindre kognitiv støj. Mere fokus på det, man faktisk prøver at gøre.
           </p>

--- a/src/pages/downloads.astro
+++ b/src/pages/downloads.astro
@@ -91,7 +91,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         <div class="card">
           <h3>Principper</h3>
           <p class="muted">
-            Arbejdsprincipperne bag local-first retning, rolig teknologi og forklarbar software.
+            Arbejdsprincipperne bag local-first retning, mindre digital støj og forklarbar software.
           </p>
           <p><a href="/principper/">Læs principper →</a></p>
         </div>

--- a/src/pages/ideer/index.astro
+++ b/src/pages/ideer/index.astro
@@ -11,13 +11,13 @@ const otherIdeer = ideer.filter((post) => !post.data.featured);
 
 <BaseLayout
   title="Idéer | Innosocia"
-  description="Essays, noter og refleksioner om digital suverænitet, local-first software og rolig teknologi."
+  description="Essays, noter og refleksioner om digital suverænitet, local-first software og mindre digital støj."
 >
 
   <section class="hero">
     <div class="wrapper">
       <p class="eyebrow">Idéer</p>
-      <h1>Tekster om digital suverænitet og rolig teknologi</h1>
+      <h1>Tekster om digital suverænitet og mere forståelige digitale systemer</h1>
       <p class="muted">
         Her samles essays, noter og refleksioner om local-first software,
         forklarbarhed, platformafhængighed og mere holdbare digitale systemer.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,7 @@ const featuredProjekter = projekter.filter((p) => p.data.featured);
 
 <BaseLayout
   title="Innosocia"
-  description="Digitale værktøjer med rygrad. Apps, idéer og projekter om local-first software, digital suverænitet og rolig teknologi."
+  description="Digitale værktøjer med mindre afhængighed. Apps, idéer og projekter om local-first software, digital suverænitet og forklarbar teknologi."
 >
   <section class="hero hero--with-bg">
     <HeroBackground />
@@ -29,11 +29,11 @@ const featuredProjekter = projekter.filter((p) => p.data.featured);
       <div class="hero-copy">
         <p class="eyebrow">Innosocia</p>
 
-        <h1>Digitale værktøjer uden platformslåsning</h1>
+        <h1>Digitale værktøjer med mindre afhængighed</h1>
 
         <p class="muted" style="font-size:1.15rem; max-width:60ch;">
           Innosocia bygger små, forklarbare apps og digitale arbejdsgange med fokus på
-          local-first retning, rolig teknologi og menneskelig dømmekraft.
+          local-first retning, mindre digital støj og mere plads til menneskelig dømmekraft.
         </p>
 
         <p class="muted" style="max-width:60ch;">
@@ -59,34 +59,33 @@ const featuredProjekter = projekter.filter((p) => p.data.featured);
       <div class="section-head">
         <h2>Kort fortalt</h2>
         <p class="muted">
-          Innosocia bygger og beskriver små, forklarbare digitale systemer,
-          der kan drives uden tung platformafhængighed.
+          Innosocia er et lille software- og udviklingsspor for mere forståelige digitale værktøjer.
         </p>
       </div>
 
       <div class="grid grid-3">
         <div class="card">
-          <h3>Bygget til praksis</h3>
+          <h3>Hvad findes nu?</h3>
           <p class="muted">
-            Apps og prototyper skal kunne forstås, vedligeholdes og bruges
-            uden at gemme hele logikken bag et sort dashboard.
+            Et offentligt site, app-sider, status, principper, samarbejdsside og en beta af Sovereign Strength.
           </p>
+          <p><a href="/status/">Se status →</a></p>
         </div>
 
         <div class="card">
-          <h3>Local-first som retning</h3>
+          <h3>Hvorfor er det anderledes?</h3>
           <p class="muted">
-            Data, drift og beslutningslogik skal så vidt muligt ligge tæt på
-            brugeren i stedet for at forsvinde ind i en fjern platform.
+            Fokus er local-first retning, forklarbar logik, lav afhængighed og digitale værktøjer, der hjælper mere end de forstyrrer.
           </p>
+          <p><a href="/principper/">Læs principper →</a></p>
         </div>
 
         <div class="card">
-          <h3>Idéer testet i virkeligheden</h3>
+          <h3>Hvad kan du gøre?</h3>
           <p class="muted">
-            Teksterne, appsene og projekterne hænger sammen:
-            idéerne skal kunne omsættes til noget, der faktisk kan køre.
+            Se apps, læs idéerne eller brug samarbejdssiden, hvis du arbejder med digitale løsninger i en organisation.
           </p>
+          <p><a href="/samarbejde/">Se samarbejde →</a></p>
         </div>
       </div>
     </div>
@@ -187,7 +186,7 @@ const featuredProjekter = projekter.filter((p) => p.data.featured);
           <h3><a href="/principper/">Læs principper</a></h3>
           <p class="muted">
             Få den korte version af retningen: local-first, forståelig logik,
-            rolig teknologi og lav platformafhængighed.
+            mindre digital støj og lav afhængighed.
           </p>
         </div>
 

--- a/src/pages/kontakt.astro
+++ b/src/pages/kontakt.astro
@@ -28,7 +28,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
       <ul>
         <li>Sovereign-apps og deres udvikling</li>
-        <li>Idéer om digital suverænitet og rolig teknologi</li>
+        <li>Idéer om digital suverænitet og mere forståelige digitale værktøjer</li>
         <li>Projekter, samarbejde eller sparring</li>
         <li>Kommunale, lokale eller civilsamfundsrettede anvendelser</li>
         <li>Feedback på sitet, teksterne eller værktøjerne</li>

--- a/src/pages/om.astro
+++ b/src/pages/om.astro
@@ -4,7 +4,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
 <BaseLayout
   title="Om | Innosocia"
-  description="Om Innosocia: et digitalt laboratorium for local-first software, digital suverænitet og rolig teknologi."
+  description="Om Innosocia: et digitalt laboratorium for local-first software, digital suverænitet og mere forståelige digitale værktøjer."
 >
   <section class="hero">
     <div class="wrapper">
@@ -12,7 +12,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       <h1>Et digitalt laboratorium for mere robuste og forståelige systemer</h1>
       <p class="muted" style="max-width: 60ch;">
         Innosocia er et udviklingsspor for apps, idéer og projekter, der tager
-        digital suverænitet, local-first software og rolig teknologi alvorligt.
+        digital suverænitet, local-first software og forståelige digitale værktøjer alvorligt.
       </p>
     </div>
   </section>
@@ -28,7 +28,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
       <p>
         Det er et sammenhængende udviklingsspor med fokus på local-first software,
-        forklarbar logik og mere rolig teknologi.
+        forklarbar logik og mindre digital støj.
       </p>
 
       <p>

--- a/src/pages/samarbejde.astro
+++ b/src/pages/samarbejde.astro
@@ -65,7 +65,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         <li>mere forståelige arbejdsgange og dokumentationsflows</li>
         <li>AI og automatisering, der understøtter dømmekraft i stedet for at erstatte den</li>
         <li>self-hosting, Nextcloud og enklere digital infrastruktur</li>
-        <li>workshops om digital suverænitet, rolig teknologi og platformafhængighed</li>
+        <li>workshops om digital suverænitet, mindre digital støj og platformafhængighed</li>
         <li>kritisk sparring på digitale projekter, hvor løsningen er ved at blive større end problemet</li>
       </ul>
     </div>
@@ -162,7 +162,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         <div class="card">
           <h3><a href="/principper/">Principper</a></h3>
           <p class="muted">
-            Grundidéerne bag rolig teknologi, digital suverænitet og local-first software.
+            Grundidéerne bag mindre digital støj, digital suverænitet og local-first software.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Updates the homepage short explanation section to answer:
  - what exists now
  - why it is different
  - what visitors can do next
- Reduces broad use of `rolig teknologi` across public pages.
- Keeps `rolig teknologi` on `/principper/`, where the concept is explained in context.
- Replaces broad calm-tech wording with clearer public language such as less digital noise, understandable tools, low dependency and tools that help more than they disturb.

## Validation
- `git diff --check` passed.
- `npm audit` returned 0 vulnerabilities.
- `npm run build` completed successfully with 21 pages generated.
- Manual local visual review looked good.
- Follow-up grep confirmed `rolig teknologi` remains only on `/principper/`.

## Risk
Low-medium. Public wording changes across multiple content pages and components. No schema, routing, deploy script, proxy config or runtime logic changes.

Related to #19.