### PR TITLE
Add homepage proof section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -167,6 +167,40 @@ const featuredProjekter = projekter.filter((p) => p.data.featured);
   <section class="section">
     <div class="wrapper">
       <div class="section-head">
+        <h2>Se arbejdet</h2>
+        <p class="muted">
+          Innosocia skal kunne efterprøves gennem status, kildekode, screenshots hvor de findes og teknisk dokumentation.
+        </p>
+      </div>
+
+      <div class="grid grid-3">
+        <div class="card">
+          <h3><a href="/status/">Status</a></h3>
+          <p class="muted">
+            Se konkrete ændringer, deploys og hvad der faktisk er flyttet på sitet.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3><a href="/downloads/">Ressourcer</a></h3>
+          <p class="muted">
+            Find GitHub-links, download-status, dokumentation og historiske udviklingsnoter.
+          </p>
+        </div>
+
+        <div class="card">
+          <h3><a href="/architecture/">Arkitektur</a></h3>
+          <p class="muted">
+            Se hvordan sitet, apps, self-hosting og dokumentation hænger teknisk sammen.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="wrapper">
+      <div class="section-head">
         <h2>Næste skridt</h2>
         <p class="muted">
           Start med det mest konkrete, læs principperne bag, eller se hvordan et samarbejde kan begynde.


### PR DESCRIPTION
## Summary
- Adds a `Se arbejdet` proof section to the homepage.
- Links visitors to Status, Ressourcer and Arkitektur.
- Makes proof elements easier to find from the public landing page.
- Uses honest wording around screenshots: `screenshots hvor de findes`.

## Validation
- `git diff --check` passed.
- `npm audit` returned 0 vulnerabilities.
- `npm run build` completed successfully with 21 pages generated.
- Manual local visual review looked good.

## Risk
Low. Homepage content-only addition. No schema, routing, deploy script, proxy config or runtime logic changes.

Related to #25.