### PR TITLE
Clarify contact page author context

### DIFF
--- a/src/pages/kontakt.astro
+++ b/src/pages/kontakt.astro
@@ -6,19 +6,88 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   title="Kontakt | Innosocia"
   description="Kontakt Innosocia om apps, idéer, projekter og samarbejde."
 >
-  <section class="hero">
+  <section class="hero contact-hero">
     <div class="wrapper">
       <p class="eyebrow">Kontakt</p>
       <h1>Kontakt Innosocia</h1>
       <p class="muted" style="max-width: 60ch;">
-        Innosocia er under opbygning, men dialog er velkommen, især hvis det handler
-        om digital suverænitet, local-first software, apps, samarbejde eller idéer,
-        der fortjener mere rygrad end standardløsningerne normalt leverer.
+        Innosocia er et personligt interesse- og udviklingsprojekt om apps,
+        idéer og dokumentation for mere forståelige digitale løsninger.
       </p>
     </div>
   </section>
 
-  <section class="section">
+  <section class="section contact-section">
+    <div class="reading">
+      <h2>Hvem står bag</h2>
+
+      <p>
+        Innosocia er drevet af Jakob Skov.
+      </p>
+
+      <p>
+        Jeg er uddannet socialrådgiver og cand.soc. i socialt arbejde og har arbejdet
+        med socialfaglig praksis, digital velfærd og brug af teknologi i offentlige organisationer.
+      </p>
+
+      <p>
+        Den tekniske del er praksisdrevet og bygget gennem konkret afprøvning:
+        små apps, open source, automatisering, selvhosting og local-first løsninger.
+      </p>
+
+      <p>
+        Innosocia er ikke en klassisk virksomhed, men et udviklingsspor for apps,
+        idéer og dokumentation om mere forståelige digitale løsninger.
+      </p>
+    </div>
+  </section>
+
+  <section class="section contact-section">
+    <div class="wrapper">
+      <div class="grid grid-2">
+        <div class="card">
+          <h2>Mail</h2>
+          <p class="muted">
+            Den mest direkte og simple måde at tage kontakt på.
+          </p>
+          <p>
+            <a href="mailto:kontakt@innosocia.dk">kontakt@innosocia.dk</a>
+          </p>
+        </div>
+
+        <div class="card">
+          <h2>LinkedIn</h2>
+          <p class="muted">
+            Jeg bruger LinkedIn som offentlig kontakt- og synlighedsflade,
+            selv om lukkede platforme ikke er idealet.
+          </p>
+          <p>
+            <a
+              href="https://www.linkedin.com/in/jakob-skov-a7031b16"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Se min LinkedIn-profil →
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section contact-section">
+    <div class="wrapper">
+      <div class="card">
+        <h2>Forventning</h2>
+        <p class="muted">
+          Innosocia er et projekt under opbygning. Derfor kan svartid variere,
+          men seriøse henvendelser bliver læst med interesse.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section contact-section">
     <div class="reading">
       <h2>Hvad du kan skrive om</h2>
 
@@ -33,46 +102,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         <li>Kommunale, lokale eller civilsamfundsrettede anvendelser</li>
         <li>Feedback på sitet, teksterne eller værktøjerne</li>
       </ul>
-    </div>
-  </section>
-
-  <section class="section">
-    <div class="wrapper">
-      <div class="grid grid-2">
-        <div class="card">
-          <h2>Mail</h2>
-          <p class="muted">
-            Den mest direkte og simple måde at tage kontakt på.
-          </p>
-          <p>
-            <a href="mailto:kontakt@innosocia.dk">kontakt@innosocia.dk</a>
-          </p>
-        </div>
-
-        <div class="card">
-          <h2>Forventning</h2>
-          <p class="muted">
-            Innosocia er et projekt under opbygning. Derfor kan svartid variere,
-            men seriøse henvendelser bliver læst med interesse.
-          </p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section class="section">
-    <div class="reading">
-      <h2>Hvem står bag</h2>
-
-      <p>
-        Innosocia er et udviklingsspor for apps, idéer og projekter med fokus på
-        mere forståelige, mere robuste og mindre platformafhængige digitale systemer.
-      </p>
-
-      <p>
-        Kontakt-siden er derfor ikke tænkt som et kundecenter, men som en åben
-        indgang for mennesker, der faktisk vil noget med teknologien, de bruger.
-      </p>
     </div>
   </section>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1799,3 +1799,33 @@ button:focus-visible,
 }
 
 
+
+/* -------------------------------- */
+/* Contact page compact layout       */
+/* -------------------------------- */
+
+.contact-hero {
+  padding-bottom: 1.5rem;
+}
+
+.contact-section {
+  padding: 2rem 0;
+}
+
+.contact-section + .contact-section {
+  padding-top: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .contact-hero {
+    padding-bottom: 1rem;
+  }
+
+  .contact-section {
+    padding: 1.5rem 0;
+  }
+
+  .contact-section + .contact-section {
+    padding-top: 0.4rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Reorders the contact page so `Hvem står bag` comes before contact options.
- Clarifies that Innosocia is a personal interest and development project driven by Jakob Skov.
- Adds relevant professional background and frames the technical work as practice-driven.
- Presents Mail and LinkedIn as clear contact cards.
- Explains LinkedIn as a practical public contact and visibility surface, without presenting closed platforms as the ideal.
- Moves expectations and contact topics into a more logical order.
- Adds contact-page-specific compact spacing to reduce excessive vertical whitespace.

## Validation
- `git diff --check` passed.
- `npm audit` returned 0 vulnerabilities.
- `npm run build` completed successfully with 21 pages generated.
- Manual mobile visual review looked good.

## Risk
Low. Contact page content/layout and page-specific spacing only. No schema, routing, deploy script, proxy config or runtime logic changes.